### PR TITLE
更新依赖版本和Java兼容性，适配Halo2.23

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 plugins {
     id 'java'
-    id "com.github.node-gradle.node" version "7.0.2"
-    id "io.freefair.lombok" version "8.0.1"
-    id "run.halo.plugin.devtools" version "0.4.0"
+    id "com.github.node-gradle.node" version "7.1.0"
+    id "io.freefair.lombok" version "8.13"
+    id "run.halo.plugin.devtools" version "0.6.1"
 }
 
 group 'cn.wangwenzhu.autobackup'
-sourceCompatibility = JavaVersion.VERSION_17
+sourceCompatibility = JavaVersion.VERSION_21
 
 repositories {
     mavenCentral()
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform('run.halo.tools.platform:plugin:2.20.0-SNAPSHOT')
+    implementation platform('run.halo.tools.platform:plugin:2.23.0')
     compileOnly 'run.halo.app:api'
 
     testImplementation 'run.halo.app:api'
@@ -52,6 +52,6 @@ build {
 }
 
 halo {
-    version = '2.20'
+    version = '2.23'
     debug = true
 }


### PR DESCRIPTION
已编译测试，可以在Halo 2.23.0正常运行