### PR TITLE
修复halo2.23版本与插件的兼容性问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 ## 介绍
 Halo自动备份插件，可以定时备份Halo的数据库和文件。
 
+## 兼容性
+- 当前分支适配 Halo `2.23.0+`
+- 修复了 Halo 升级后 `SettingFetcher` 二进制兼容导致的启动错误
+
 ## 使用方式
 1. 下载地址：https://github.com/yuxuefenfei/halo-plugin-auto-backup/releases
 2. 插件安装：登录Halo后台，在系统->插件->安装->本地上传页面上传插件

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
-version=1.1.1
+version=1.1.2
+org.gradle.jvmargs=-Dfile.encoding=UTF-8
 
 # http
 # systemProp.https.proxyHost=127.0.0.1

--- a/src/main/java/cn/wangwenzhu/autobackup/AutoBackupTask.java
+++ b/src/main/java/cn/wangwenzhu/autobackup/AutoBackupTask.java
@@ -19,7 +19,6 @@ import run.halo.app.extension.ExtensionClient;
 import run.halo.app.extension.ListOptions;
 import run.halo.app.extension.Metadata;
 import run.halo.app.migration.Backup;
-import run.halo.app.plugin.SettingFetcher;
 
 @Log4j2
 @Component
@@ -32,9 +31,9 @@ public class AutoBackupTask extends AbstractReschedulingConfigurer {
 
     private final ExtensionClient client;
 
-    private final SettingFetcher settingFetcher;
+    private final SettingFetcherCompat settingFetcher;
 
-    public AutoBackupTask(ExtensionClient client, SettingFetcher settingFetcher) {
+    public AutoBackupTask(ExtensionClient client, SettingFetcherCompat settingFetcher) {
         super(true);
         this.client = client;
         this.settingFetcher = settingFetcher;
@@ -56,8 +55,7 @@ public class AutoBackupTask extends AbstractReschedulingConfigurer {
 
         client.create(backup);
 
-        Optional<AutoBackupConfig> config =
-            settingFetcher.fetch("base", AutoBackupConfig.class);
+        Optional<AutoBackupConfig> config = settingFetcher.fetch("base", AutoBackupConfig.class);
 
         if (config.isPresent()) {
             int maxBackupCount = config.get().getMaxBackupCount();
@@ -77,8 +75,7 @@ public class AutoBackupTask extends AbstractReschedulingConfigurer {
     public Task configureTask() {
         return new TriggerTask(this::autoBackup, triggerContext -> {
 
-            Optional<AutoBackupConfig> config =
-                settingFetcher.fetch("base", AutoBackupConfig.class);
+            Optional<AutoBackupConfig> config = settingFetcher.fetch("base", AutoBackupConfig.class);
 
             if (config.isPresent()) {
                 String timeUnit = config.get().getTimeUnit();

--- a/src/main/java/cn/wangwenzhu/autobackup/SettingFetcherCompat.java
+++ b/src/main/java/cn/wangwenzhu/autobackup/SettingFetcherCompat.java
@@ -1,0 +1,37 @@
+package cn.wangwenzhu.autobackup;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Optional;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SettingFetcherCompat {
+
+    private final Object settingFetcherBean;
+    private final Method fetchMethod;
+
+    public SettingFetcherCompat(ApplicationContext applicationContext) {
+        try {
+            Class<?> settingFetcherClass = Class.forName("run.halo.app.plugin.SettingFetcher");
+            this.settingFetcherBean = applicationContext.getBean(settingFetcherClass);
+            this.fetchMethod = settingFetcherClass.getMethod("fetch", String.class, Class.class);
+        } catch (ClassNotFoundException | NoSuchMethodException ex) {
+            throw new IllegalStateException("Cannot resolve Halo SettingFetcher API", ex);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> Optional<T> fetch(String group, Class<T> clazz) {
+        try {
+            Object result = fetchMethod.invoke(settingFetcherBean, group, clazz);
+            if (!(result instanceof Optional<?> optional)) {
+                return Optional.empty();
+            }
+            return optional.map(clazz::cast);
+        } catch (IllegalAccessException | InvocationTargetException ex) {
+            throw new IllegalStateException("Failed to invoke SettingFetcher.fetch", ex);
+        }
+    }
+}

--- a/src/main/resources/plugin.yaml
+++ b/src/main/resources/plugin.yaml
@@ -5,7 +5,7 @@ metadata:
   name: halo-plugin-auto-backup
 spec:
   enabled: true
-  requires: ">=2.17.0"
+  requires: ">=2.23.0"
   author:
     name: 贴心小王
     website: https://wangwenzhu.cn


### PR DESCRIPTION
   背景
   插件在 Halo 2.23.0 启动时报错：
   `java.lang.IncompatibleClassChangeError: Found interface run.halo.app.plugin.SettingFetcher, but class was
  expected`
   问题触发点在 `AutoBackupTask` 读取设置时，属于 `SettingFetcher` 相关 ABI 兼容问题。

   改动内容
   新增 `SettingFetcherCompat`，通过反射调用
  `SettingFetcher.fetch(...)`，避免直接字节码绑定导致的接口/类形态不兼容。
   `AutoBackupTask` 改为依赖 `SettingFetcherCompat`。
   `plugin.yaml` 中 `requires` 调整为 `>=2.23.0`。
   版本号更新为 `1.1.2`（`gradle.properties`）。
   README 增加 Halo 2.23.0+ 兼容说明。
   验证
   环境：JDK 21
   命令：`./gradlew clean build --no-daemon`
   结果：`BUILD SUCCESSFUL`
   产物：`build/libs/halo-plugin-auto-backup-1.1.2.jar`
   影响范围
   不改变原有功能逻辑（定时备份、保留数量清理）。
   主要为 Halo 2.23.0 的启动兼容性修复。